### PR TITLE
Failed process recovery.

### DIFF
--- a/disref/process.py
+++ b/disref/process.py
@@ -2,6 +2,7 @@ import redis
 import uuid
 import time
 import threading
+import math
 
 from disref import get_logger, DisRefError, DISREF_NAMESPACE
 from disref.reference import Reference
@@ -32,6 +33,7 @@ class Process(object):
                 establishing the lock.
             """
             self.block = block
+            lock_key = "{0}.lock".format(lock_key)
             self.lock_key = lock_key
             self.client = process.client
             self.__process = process
@@ -55,7 +57,7 @@ class Process(object):
     class AlreadyLocked(DisRefError):
         pass
 
-    def __init__(self, session_length=int(0.5*TTL), host='localhost', port=6379, db=1, heartbeat_interval=10):
+    def __init__(self, session_length=int(0.5*TTL), host='localhost', port=6379, db=1, heartbeat_interval=10, recover_failed_processes=True):
         """
         :param session_length int: The session length for the resource. e.g. If
             this represents an update for a User, the session_length would be
@@ -65,9 +67,13 @@ class Process(object):
         :param int port: The port to connect to redis on.
         :param int heartbeat_interval: The frequency in seconds with which to
             update the heartbeat for this process.
+        :param bool recover_failed_processes: Determines whether this process
+            attempt to recover references from other failed processes.
+
         """
         self.id = unicode(uuid.uuid4())
         self.session_length = session_length
+        self.recover_failed_processes = recover_failed_processes
 
         if not hasattr(Process, 'client'):
             Process.client = redis.StrictRedis(host=host, port=port, db=db)
@@ -80,7 +86,7 @@ class Process(object):
 
         self.client = Process.client
 
-        self.registry_key = "{0}_{1}".format(DISREF_NAMESPACE, self.id)
+        self.registry_key = self._get_registry_key(self.id)
 
         self.heartbeat_interval = heartbeat_interval
         self.heartbeat_hash_name = "{0}_heartbeat".format(DISREF_NAMESPACE)
@@ -100,22 +106,71 @@ class Process(object):
         :returns: The created Reference object
         """
 
-        self.client.hset(self.registry_key, resource, 1)
+        self.add_to_registry(resource)
         return Reference(self, resource, block)
+
+    def add_to_registry(self, resource, registry_key=None):
+        """
+        Adds a particular resource key to a process registry
+
+        :param str resource: An identifier for the resource.
+        :param str registry_key: Optional. The registry to which the
+            resource should be added.  If not specific, the resource
+            will be added to this process.
+
+        """
+        if registry_key is None:
+            registry_key = self.registry_key
+
+        return self.client.hset(self.registry_key, resource, 1)
+
+    def remove_from_registry(self, resource, registry_key=None):
+        """
+        Removes a particular resource key from a process registry
+
+        :param str resource: An identifier for the resource.
+        :param str registry_key: Optional. The registry from which the
+            resource should be removed.  If not specific, the resource
+            will be removed from this process.
+
+        """
+        if registry_key is None:
+            registry_key = self.registry_key
+
+        return self.client.hdel(self.registry_key, resource)
+
+    def get_registry(self, registry_key=None):
+        """
+        Returns a list of all items in a process' registry, excluding any
+        resources automatically created by each process.  As these are added,
+        they should be added to the REGISTRY_EXCLUSIONS below.
+
+        :param str registry_key: Optional. The registry for which to return
+            the registry.  If not specified, returns this process's registry.
+
+        """
+
+        REGISTRY_EXCLUSIONS = [self.heartbeat_hash_name]
+
+        if registry_key is None:
+            registry_key = self.registry_key
+
+        return filter(lambda s: s not in REGISTRY_EXCLUSIONS, self.client.hkeys(registry_key))
 
     def lock(self, lock_key, block=True):
         """
         Issues a lock for a given key.
-
         Usage:
             with process.lock( some_key ):
                 pass
-
         :param str lock_key: The key to lock
         :param bool block: Optional. Whether or not to block when establishing
             lock.
         """
         return Process.Lock(self, lock_key, block)
+
+    def _get_registry_key(self, pid):
+        return "{0}_{1}".format(DISREF_NAMESPACE, pid)
 
     def __update_heartbeat(self):
         """
@@ -126,12 +181,62 @@ class Process(object):
             self.__heartbeat_timer.cancel()
             self.__heartbeat_timer = None
 
-        with self.lock(self.__heartbeat_ref.lock_key):
+        with self.lock(self.__heartbeat_ref.resource_key):
             self.client.hset(self.heartbeat_hash_name, self.id, int(time.time()))
+
+        if self.recover_failed_processes:
+            self.__recover_failed_processes()
 
         self.__heartbeat_timer = threading.Timer(self.heartbeat_interval, self.__update_heartbeat)
         self.__heartbeat_timer.daemon = True
         self.__heartbeat_timer.start()
+
+    def __recover_failed_processes(self):
+        """
+        Checks the health of all processes by checking the last time each
+        heartbeat was updated, and recovers the references for any process
+        which has died.
+
+        """
+        failed_pids = []
+        heartbeats = self.client.hgetall(self.heartbeat_hash_name)
+        for pid, heartbeat_time in heartbeats.items():
+            if int(float(heartbeat_time)) <= int(time.time()) - 5*self.heartbeat_interval:
+                failed_pids.append(pid)
+
+        active_process_count = len(heartbeats) - len(failed_pids)
+
+        for failed_pid in failed_pids:
+            failed_process_registry_key = self._get_registry_key(failed_pid)
+
+            try:
+                with self.lock(failed_process_registry_key):
+                    if failed_pid == self.id:
+                        # The failed process has come back to life.  Its old registry remains
+                        # intact in redis under the old process_id and will be
+                        # recovered by other processes.  By assigning a new id this process's
+                        # registry begins fresh.
+                        self.id = unicode(uuid.uuid4())
+                        self.registry_key = self._get_registry_key(self.id)
+                    elif active_process_count:
+                        failed_process_registry = self.client.hkeys(failed_process_registry_key)
+                        recovering_references = failed_process_registry[0:int(math.ceil(float(len(failed_process_registry))/active_process_count))]
+
+                        for recovering_reference in recovering_references:
+                            reference = self.create_reference(recovering_reference)
+                            with reference.lock():
+                                reference.remove_failed_process(failed_pid)
+
+                        if self.remove_from_registry(recovering_references, failed_process_registry_key) == 0:
+                            # No futher references to recover.
+                            self.client.hdel(self.heartbeat_hash_name, failed_pid)
+                    else:
+                        logger.error("There is no active process with which to \
+                            recover your references.")
+
+            except Process.AlreadyLocked:
+                logger.warning("Registry already locked. Remaining references \
+                    will be recovered on next available heartbeat update.")
 
     def stop(self):
         """

--- a/disref/update.py
+++ b/disref/update.py
@@ -33,7 +33,7 @@ class Update(object):
     from redis.
     """
 
-    def __init__(self, process, _id, database='test', collection='test', spec=None, doc=None, block=True):
+    def __init__(self, process, _id, database='test', collection='test', spec=None, doc=None, init_cache=True, block=True):
         """
         :param Process process: The process object, unique to the node.
         :param str _id: The primary key for the record in the database.
@@ -41,6 +41,9 @@ class Update(object):
         :param dict spec: A specification to use in looking up records to
             update.
         :param dict doc: A dictionary of representing the data to update.
+        :param bool init_cache: Optional. Determines whether the update should
+            cache immediately.  While this will allow for more complete recovery
+            of data in the event of a node failure, it may reduce performance.
         :param bool block: Optional. Whether or not to block when establishing
             locks.
         """
@@ -50,8 +53,11 @@ class Update(object):
         self.doc = doc
         self.collection = collection
         self.database = database
-        self.ref = Reference(process=process, resource=self.resource_id, block=block)
         self.__process = process
+        self.ref = self.__process.create_reference(resource=self.resource_id, block=block)
+
+        if init_cache:
+            self.__cache()
 
     def end_session(self, block=True):
         """
@@ -74,7 +80,7 @@ class Update(object):
         if self.ref.get_times_modified() > 0:
             cached = json.loads(self.__process.client.get(self.resource_id) or "{}")
             self.merge(cached)
-        self.cache() 
+        self.cache()
         self.ref.increment_times_modified()
 
     def __execute(self):

--- a/test.py
+++ b/test.py
@@ -7,6 +7,7 @@ import datetime
 import pytz
 import time
 import logging
+import uuid
 
 from disref.reference import Reference
 from disref.process import Process
@@ -60,7 +61,7 @@ class ProcessTest(unittest.TestCase):
 
     @mock.patch('time.time', side_effect=get_milliseconds_timestamp)
     def test_heartbeat_updates(self, time_time_patched):
-        p = Process(heartbeat_interval=.1)
+        p = Process(heartbeat_interval=.1, recover_failed_processes=False)
 
         current_time = p.client.hget(p.heartbeat_hash_name, p.id)
 
@@ -74,8 +75,8 @@ class ProcessTest(unittest.TestCase):
 
     @mock.patch('time.time', side_effect=get_milliseconds_timestamp)
     def test_multiple_heartbeats_update(self, time_time_patched):
-        p1 = Process(heartbeat_interval=.1)
-        p2 = Process(heartbeat_interval=.1)
+        p1 = Process(heartbeat_interval=.1, recover_failed_processes=False)
+        p2 = Process(heartbeat_interval=.1, recover_failed_processes=False)
 
         current_time_1 = p1.client.hget(p1.heartbeat_hash_name, p1.id)
         current_time_2 = p2.client.hget(p2.heartbeat_hash_name, p2.id)
@@ -93,8 +94,8 @@ class ProcessTest(unittest.TestCase):
 
     @mock.patch('time.time', side_effect=get_milliseconds_timestamp)
     def test_stop_cleans_up(self, time_time_patched):
-        p1 = Process(heartbeat_interval=.1)
-        p2 = Process(heartbeat_interval=.1)
+        p1 = Process(heartbeat_interval=.1, recover_failed_processes=False)
+        p2 = Process(heartbeat_interval=.1, recover_failed_processes=False)
 
         current_time_1 = p1.client.hget(p1.heartbeat_hash_name, p1.id)
 
@@ -131,7 +132,7 @@ class ProcessTest(unittest.TestCase):
 
         assert lock.block is True
         assert lock2.block is False
-        assert lock.lock_key is "foo"
+        assert lock.lock_key == "foo.lock"
         assert lock.client is p1.client
         assert lock._Lock__process is p1
         assert lock._Lock__lock is None
@@ -143,6 +144,57 @@ class ProcessTest(unittest.TestCase):
             self.assertRaises(Process.AlreadyLocked, lock2.__enter__)
 
         p1.stop()
+
+    def test_process_recovery(self):
+        p1 = Process(heartbeat_interval=.1)
+        p1._Process__heartbeat_timer.cancel()
+
+        assert len(p1.get_registry()) == 0
+
+        dead_process_registry = p1._get_registry_key("12345")
+        p1.add_to_registry("r1", dead_process_registry)
+        p1.add_to_registry("r2", dead_process_registry)
+        p1.client.hset(p1.heartbeat_hash_name, "12345", int(time.time()) - 6 * p1.heartbeat_interval)
+
+        p1._Process__recover_failed_processes()
+
+        assert len(p1.get_registry()) == 2
+        assert "12345" not in p1.client.hgetall(p1.heartbeat_hash_name)
+
+        ref = p1.create_reference("r1")
+        ref_list = json.loads(p1.client.get(ref.reflist_key))
+        assert "12345" not in ref_list
+        assert p1.id in ref_list
+
+        ref = p1.create_reference("r2")
+        ref_list = json.loads(p1.client.get(ref.reflist_key))
+        assert "12345" not in ref_list
+        assert p1.id in ref_list
+
+        p1.stop()
+
+
+    def test_process_self_recovery(self):
+        p1 = Process(heartbeat_interval=.1)
+
+        p1.create_reference("test")
+        p1._Process__heartbeat_timer.cancel()
+
+        original_id = p1.id
+        p1.client.hset(p1.heartbeat_hash_name, original_id, int(time.time()) - 6 * p1.heartbeat_interval)
+
+        p1._Process__recover_failed_processes()
+
+        assert p1.id != original_id
+        assert len(p1.get_registry()) == 0
+
+        p1._Process__update_heartbeat()
+        p1._Process__heartbeat_timer.cancel()
+
+        assert len(p1.get_registry()) == 1
+
+        p1.stop()
+
 
 
 class ReferenceTest(unittest.TestCase):
@@ -405,7 +457,7 @@ class UpdateTest(unittest.TestCase):
     def test_initializer_updates_ref_count(self):
         p = Process()
         a = UpdateTest.UserUpdate(process=p,  _id='123', database='test', collection='user',
-                spec={'_id': 123}, doc={'a': 1., 'b': 2., 'c': 3.})
+                spec={'_id': 123}, doc={'a': 1., 'b': 2., 'c': 3.}, init_cache=False)
 
         client = a._Update__process.client
         reflist = json.loads(client.get(a.ref.reflist_key) or "{}")
@@ -417,7 +469,7 @@ class UpdateTest(unittest.TestCase):
     def test_cache_caches(self):
         p = Process()
         a = UpdateTest.UserUpdate(process=p, _id='12345', database='test', collection='user',
-                spec={'_id': 12345}, doc={'a': 1., 'b': 2., 'c': 3.})
+                spec={'_id': 12345}, doc={'a': 1., 'b': 2., 'c': 3.}, init_cache=False)
         a.cache()
         client = a._Update__process.client
         cached = json.loads(client.get(a.resource_id) or "{}")
@@ -428,10 +480,10 @@ class UpdateTest(unittest.TestCase):
 
         client.flushall()
         b = UpdateTest.UserUpdate(process=p, _id='456', database='test', collection='user',
-                spec= {u'_id': 456}, doc={'d': 4., 'e': 5., 'f': 6.})
+                spec= {u'_id': 456}, doc={'d': 4., 'e': 5., 'f': 6.}, init_cache=False)
         p2 = Process()
         c = UpdateTest.UserUpdate(process=p2, _id='456', database='test', collection='user',
-                spec= {u'_id': 456}, doc={'d': 4., 'e': 5., 'f': 6.})
+                spec= {u'_id': 456}, doc={'d': 4., 'e': 5., 'f': 6.}, init_cache=False)
 
         client = a._Update__process.client
         assert client.get(b.resource_id) is None, client.get(b.resource_id)
@@ -479,6 +531,50 @@ class UpdateTest(unittest.TestCase):
 
         p.stop()
         p2.stop()
+
+    def test_data_is_recovered(self):
+        p = Process()
+        client = p.client
+
+        client.flushall()
+
+        a = UpdateTest.UserUpdate(process=p, _id='12345', database='test', collection='user',
+                spec={'_id': 12345}, doc={'a': 1., 'b': 2., 'c': 3.})
+
+        p._Process__heartbeat_timer.cancel()
+
+        assert len(p.get_registry()) == 1
+
+        cached = json.loads(client.get(a.resource_id) or "{}")
+
+        assert cached == {u'doc': {u'a': 1.0, u'c': 3.0, u'b': 2.0},
+            u'spec': {u'_id': 12345},
+            u'collection': u'user', 
+            u'database': u'test'}
+
+        p.client.hset(p.heartbeat_hash_name, p.id, int(time.time()) - 6*p.heartbeat_interval)
+
+        p.id = unicode(uuid.uuid4())
+        p.registry_key = p._get_registry_key(p.id)
+
+        assert len(p.get_registry()) == 0
+
+        p._Process__update_heartbeat()
+        p._Process__heartbeat_timer.cancel()
+
+        assert len(p.get_registry()) == 1
+
+        a = UpdateTest.UserUpdate(process=p, _id='12345', database='test', collection='user',
+                spec={'_id': 12345}, doc={'a': 1., 'b': 2., 'c': 3.})
+
+        cached = json.loads(client.get(a.resource_id) or "{}")
+
+        assert cached == {u'doc': {u'a': 2.0, u'c': 6.0, u'b': 4.0},
+            u'spec': {u'_id': 12345},
+            u'collection': u'user', 
+            u'database': u'test'}
+
+        p.stop()
 
     def test_end_session_raises_when_deadlocked(self):
         pass
@@ -564,7 +660,6 @@ class LruCacheTest(unittest.TestCase):
         self.cache.expire('a')
         assert self.cache.size() == 1
         a.assert_end_session_called()
-
 
     def test_expire_all_expires_all(self):
         updates = [self.get_update('a'),


### PR DESCRIPTION
On update of the heartbeat for each process, verify that the other processes are still alive.  If not, distribute the references from the dead process among the live processes. 